### PR TITLE
Added Viaplay to application dict

### DIFF
--- a/custom_components/samsungtv_custom/samsungctl_qled/application.py
+++ b/custom_components/samsungtv_custom/samsungctl_qled/application.py
@@ -26,7 +26,8 @@ APPS = {'YouTube': '111299001912',
         'Facebook Watch': '11091000000',
         'McAfee Security for TV': '3201612011418',
         'OCS': '3201703012029',
-        'Playzer': '3201810017091'
+        'Playzer': '3201810017091',
+        'Viaplay': '11111300404'
         }
 
 


### PR DESCRIPTION
Retrieved using https://github.com/marysieek/samsung-tv-api
Tested on a model UE55MU6195

Partially solves comment in issue #21 