### PR TITLE
Added version and defined media_player dependency

### DIFF
--- a/custom_components/samsungtv_custom/manifest.json
+++ b/custom_components/samsungtv_custom/manifest.json
@@ -2,9 +2,10 @@
   "domain": "samsungtv_custom",
   "name": "Samsungtv Custom",
   "documentation": "https://github.com/roberodin/ha-samsungtv-custom",
-  "requirements": ["wakeonlan==1.1.6"
-  ],
-  "dependencies": [],
+  "requirements": ["wakeonlan==1.1.6"],
+  "dependencies": ["media_player"],
   "codeowners": ["@roberodin"],
+  "version": "3.0.5",
   "homeassistant": "0.90.0"
 }
+


### PR DESCRIPTION
This allows the plugin to load again on current versions of Home Assistant. Tested on Home Assistant 2021.10.4 and HACS Integration version: 1.15.2